### PR TITLE
feat: add ability to switch between projects in the knowledge graph

### DIFF
--- a/notes/next_steps.md
+++ b/notes/next_steps.md
@@ -163,6 +163,12 @@ This ensures agents make effective use of the memory system.
     - Identify unused or duplicated code
     - Suggest cleanup actions
 
+- [ ] **Implement ndjson for knowledgegraph persistence**
+
+  - Purpose: easy analysis and querying
+  - Motivation: as the knowledge graph grows, it becomes more difficult to analyze and query the data in its current format, since it all needs to be loaded into memory.
+  - Implementation: Rework knowledgegraph apis to use ndjson/streaming as needed
+
 - [ ] **Implement Branch Reconciliation**
 
   - Purpose: Ensure final decisions are consolidated across branches

--- a/src/agents/Summarize.ts
+++ b/src/agents/Summarize.ts
@@ -50,6 +50,16 @@ export class SummarizationAgent {
   }
 
   /**
+   * Initializes or reinitializes the agent.
+   * This can be called when switching projects to reset internal state.
+   */
+  init(): void {
+    console.log(
+      `[SummarizationAgent] Initialized for project: ${this.knowledgeGraph.getCurrentProject()}`,
+    );
+  }
+
+  /**
    * Summarizes a segment of nodes from the knowledge graph.
    * @param nodes Array of DagNode objects to summarize
    * @returns A promise that resolves to a SummarizationResult with just the summary text

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,20 +3,198 @@ import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 // -----------------------------------------------------------------------------
-// Configuration ----------------------------------------------------------------
+// Path Configuration ----------------------------------------------------------
 // -----------------------------------------------------------------------------
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const dataDir = path.resolve(__dirname, '..', 'data');
-const defaultMemoryFilePath = path.resolve(dataDir, 'kg.json');
+const projectConfigPath = path.resolve(dataDir, 'currentProject.json');
+const legacyMemoryFilePath = path.resolve(dataDir, 'kg.json');
 
+// Initialize data directory if it doesn't exist
 if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
-if (!fs.existsSync(defaultMemoryFilePath)) fs.writeFileSync(defaultMemoryFilePath, '{}', 'utf8');
+
+// -----------------------------------------------------------------------------
+// Project Configuration -------------------------------------------------------
+// -----------------------------------------------------------------------------
+
+// Initialize or load current project configuration
+let currentProject = 'default';
+try {
+  if (fs.existsSync(projectConfigPath)) {
+    const projectConfig = JSON.parse(fs.readFileSync(projectConfigPath, 'utf8'));
+    currentProject = projectConfig.currentProject || 'default';
+  } else {
+    fs.writeFileSync(projectConfigPath, JSON.stringify({ currentProject }, null, 2), 'utf8');
+  }
+} catch (err) {
+  console.error('Error loading project configuration, using default:', err);
+}
+
+// -----------------------------------------------------------------------------
+// File Operations -------------------------------------------------------------
+// -----------------------------------------------------------------------------
+
+/**
+ * Get the file path for a specific project
+ * @param projectName The name of the project
+ * @returns The file path for the specified project
+ */
+function getProjectFilePath(projectName: string): string {
+  return path.resolve(dataDir, `kg.${projectName}.json`);
+}
+
+/**
+ * List all available project files
+ * @returns Array of project names extracted from file names
+ */
+function listProjectFiles(): string[] {
+  try {
+    const files = fs.readdirSync(dataDir);
+    return files
+      .filter((file) => file.startsWith('kg.') && file.endsWith('.json') && file !== 'kg.json')
+      .map((file) => file.replace(/^kg\./, '').replace(/\.json$/, ''));
+  } catch (err) {
+    console.error('Error listing project files:', err);
+    return [];
+  }
+}
+
+/**
+ * Create a new project file
+ * @param projectName Name of the new project to create
+ * @returns True if the project file was created successfully, false otherwise
+ */
+function createProjectFile(projectName: string): boolean {
+  try {
+    const projectPath = getProjectFilePath(projectName);
+
+    // Check if project already exists
+    if (fs.existsSync(projectPath)) {
+      return false; // Project already exists
+    }
+
+    // Create the project file
+    fs.writeFileSync(projectPath, '{}', 'utf8');
+
+    return true;
+  } catch (err) {
+    console.error('Error creating project file:', err);
+    return false;
+  }
+}
+
+/**
+ * Set the current project in the configuration file
+ * @param projectName Name of the project to set as current
+ * @returns True if the project was set as current successfully, false otherwise
+ */
+function setCurrentProjectFile(projectName: string): boolean {
+  try {
+    const projectPath = getProjectFilePath(projectName);
+
+    // Create the project file if it doesn't exist
+    if (!fs.existsSync(projectPath)) {
+      fs.writeFileSync(projectPath, '{}', 'utf8');
+    }
+
+    // Update the current project configuration
+    fs.writeFileSync(
+      projectConfigPath,
+      JSON.stringify({ currentProject: projectName }, null, 2),
+      'utf8',
+    );
+
+    return true;
+  } catch (err) {
+    console.error('Error setting current project file:', err);
+    return false;
+  }
+}
+
+/**
+ * File operations for managing project files
+ */
+export const FileOps = {
+  /**
+   * Get the file path for a specific project
+   * @param projectName The name of the project
+   * @returns The file path for the specified project
+   */
+  getProjectFilePath,
+
+  /**
+   * List all available project files
+   * @returns Array of project names extracted from file names
+   */
+  listProjectFiles,
+
+  /**
+   * Create a new project file
+   * @param projectName Name of the new project to create
+   * @returns True if the project file was created successfully, false otherwise
+   */
+  createProjectFile,
+
+  /**
+   * Set the current project in the configuration file
+   * @param projectName Name of the project to set as current
+   * @returns True if the project was set as current successfully, false otherwise
+   */
+  setCurrentProjectFile,
+};
+
+// Get the current project's memory file path
+const currentMemoryFilePath = getProjectFilePath(currentProject);
+
+// Initialize the current project's memory file if it doesn't exist
+if (!fs.existsSync(currentMemoryFilePath)) {
+  fs.writeFileSync(currentMemoryFilePath, '{}', 'utf8');
+}
+
+// Handle migration from legacy kg.json to project-based structure
+if (fs.existsSync(legacyMemoryFilePath)) {
+  try {
+    const stats = fs.statSync(legacyMemoryFilePath);
+    if (!stats.isSymbolicLink() && stats.size > 2) {
+      // Size > 2 means it's not just '{}'
+      // If this is the first time setting up projects, and we have existing data in kg.json,
+      // move it to the default project file
+      const defaultProjectPath = getProjectFilePath('default');
+      if (
+        !fs.existsSync(defaultProjectPath) ||
+        fs.readFileSync(defaultProjectPath, 'utf8') === '{}'
+      ) {
+        fs.copyFileSync(legacyMemoryFilePath, defaultProjectPath);
+      }
+    }
+  } catch (err) {
+    console.error('Error handling legacy file migration:', err);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Configuration Constants -----------------------------------------------------
+// -----------------------------------------------------------------------------
 
 export const CFG = {
+  // Application settings
   WINDOW: Number(process.env.WINDOW ?? 20),
   CRITIC_EVERY_N_STEPS: Number(process.env.critic_every_n_steps ?? 3),
   MAX_REVISION_CYCLES: Number(process.env.max_revision_cycles ?? 2),
-  MEMORY_FILE_PATH: process.env.MEMORY_FILE_PATH ?? defaultMemoryFilePath,
+
+  // Project settings
+  MEMORY_FILE_PATH: process.env.MEMORY_FILE_PATH ?? currentMemoryFilePath,
+  CURRENT_PROJECT: currentProject,
+  PROJECT_CONFIG_PATH: projectConfigPath,
+
+  // For backward compatibility
+  getProjectMemoryFilePath: getProjectFilePath,
+  listProjects: listProjectFiles,
+  switchProject: setCurrentProjectFile,
+  createProject: createProjectFile,
+
+  // File operations
+  FileOps,
 };

--- a/src/engine/KnowledgeGraph.project.test.ts
+++ b/src/engine/KnowledgeGraph.project.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { KnowledgeGraphManager } from './KnowledgeGraph';
+import { ProjectManager } from './ProjectManager';
+import fs from 'node:fs/promises';
+import { CFG, FileOps } from '../config';
+import path from 'node:path';
+
+// Mock fs module
+vi.mock('node:fs/promises', () => {
+  return {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    default: {
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+    },
+  };
+});
+
+// Mock node:fs module (used in config.ts)
+vi.mock('node:fs', () => {
+  return {
+    existsSync: vi.fn().mockReturnValue(true),
+    statSync: vi.fn().mockReturnValue({
+      isSymbolicLink: vi.fn().mockReturnValue(false),
+      size: 10, // Not empty
+    }),
+    readdirSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    copyFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    symlinkSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    default: {
+      existsSync: vi.fn().mockReturnValue(true),
+      statSync: vi.fn().mockReturnValue({
+        isSymbolicLink: vi.fn().mockReturnValue(false),
+        size: 10, // Not empty
+      }),
+      readdirSync: vi.fn(),
+      readFileSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      unlinkSync: vi.fn(),
+      symlinkSync: vi.fn(),
+      mkdirSync: vi.fn(),
+    },
+  };
+});
+
+describe('KnowledgeGraphManager Project Management', () => {
+  let kg: KnowledgeGraphManager;
+  let projectManager: ProjectManager;
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock config functions
+    vi.spyOn(FileOps, 'listProjectFiles').mockReturnValue(['default', 'project1', 'project2']);
+    vi.spyOn(FileOps, 'createProjectFile').mockReturnValue(true);
+    vi.spyOn(FileOps, 'setCurrentProjectFile').mockReturnValue(true);
+    vi.spyOn(FileOps, 'getProjectFilePath').mockImplementation((projectName) => {
+      return path.resolve('/test/path', `kg.${projectName}.json`);
+    });
+
+    // Mock the current project in CFG
+    Object.defineProperty(CFG, 'CURRENT_PROJECT', {
+      value: 'default',
+      writable: true,
+    });
+
+    // Create ProjectManager instance
+    projectManager = new ProjectManager();
+
+    // Create KnowledgeGraphManager instance with ProjectManager
+    kg = new KnowledgeGraphManager(projectManager);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Project Management', () => {
+    it('should use the ProjectManager to get project information', () => {
+      // Mock the current project in CFG
+      Object.defineProperty(CFG, 'CURRENT_PROJECT', {
+        value: 'testproject',
+        writable: true,
+      });
+
+      expect(projectManager.getCurrentProject()).toBe('testproject');
+      expect(projectManager.getCurrentProjectPath()).toBe('/test/path/kg.testproject.json');
+    });
+
+    it('should switch to an existing project', async () => {
+      // Mock readFile to return empty entities and relations
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ entities: {}, relations: [] }));
+
+      // Mock getCurrentProjectPath to return the correct path
+      vi.spyOn(projectManager, 'getCurrentProjectPath').mockReturnValue(
+        '/test/path/kg.project1.json',
+      );
+
+      const result = await kg.switchProject('project1');
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Successfully switched to project: project1');
+      expect(FileOps.setCurrentProjectFile).toHaveBeenCalledWith('project1');
+      expect(fs.readFile).toHaveBeenCalledWith('/test/path/kg.project1.json', 'utf8');
+    });
+
+    it('should handle errors when switching projects', async () => {
+      // Mock setCurrentProjectFile to return false (switch failed)
+      vi.spyOn(FileOps, 'setCurrentProjectFile').mockReturnValue(false);
+
+      const result = await kg.switchProject('nonexistent');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Project 'nonexistent' does not exist");
+    });
+
+    it('should reject invalid project names when switching', async () => {
+      const result = await kg.switchProject('invalid/project');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe(
+        'Project name can only contain letters, numbers, dashes, and underscores',
+      );
+      expect(FileOps.setCurrentProjectFile).not.toHaveBeenCalled();
+    });
+
+    it('should flush changes before switching projects', async () => {
+      // Make the graph dirty
+      kg['dirty'] = true;
+
+      // Mock readFile to return empty entities and relations
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ entities: {}, relations: [] }));
+
+      await kg.switchProject('project2');
+
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    it('should handle read errors when switching projects', async () => {
+      // Mock readFile to throw an error
+      vi.mocked(fs.readFile).mockRejectedValue(new Error('Read error'));
+
+      const result = await kg.switchProject('project1');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('Error switching to project: Read error');
+    });
+  });
+});

--- a/src/engine/KnowledgeGraph.project.test.ts
+++ b/src/engine/KnowledgeGraph.project.test.ts
@@ -92,6 +92,7 @@ describe('KnowledgeGraphManager Project Management', () => {
 
       expect(projectManager.getCurrentProject()).toBe('testproject');
       expect(projectManager.getCurrentProjectPath()).toBe('/test/path/kg.testproject.json');
+      expect(kg.getCurrentProject()).toBe('testproject');
     });
 
     it('should switch to an existing project', async () => {

--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { KnowledgeGraphManager, DagNode, ArtifactRef } from './KnowledgeGraph';
+import { ProjectManager } from './ProjectManager';
 import fs from 'node:fs/promises';
 import { v4 as uuid } from 'uuid';
 
@@ -18,6 +19,7 @@ vi.mock('node:fs/promises', () => {
 describe('KnowledgeGraphManager', () => {
   const testFilePath = '/test/path/kg.json';
   let kg: KnowledgeGraphManager;
+  let projectManager: ProjectManager;
 
   // Helper function to create a test node
   function createTestNode(
@@ -43,6 +45,17 @@ describe('KnowledgeGraphManager', () => {
     };
   }
 
+  // Mock ProjectManager class
+  class MockProjectManager {
+    getCurrentProject = vi.fn().mockReturnValue('default');
+    getCurrentProjectPath = vi.fn().mockReturnValue(testFilePath);
+    getProjectPath = vi.fn().mockReturnValue(testFilePath);
+    listProjects = vi.fn().mockReturnValue(['default']);
+    validateProjectName = vi.fn();
+    switchProject = vi.fn();
+    createProject = vi.fn();
+  }
+
   beforeEach(() => {
     // Reset mocks
     vi.resetAllMocks();
@@ -50,8 +63,11 @@ describe('KnowledgeGraphManager', () => {
     // Mock readFile to return empty JSON by default
     vi.mocked(fs.readFile).mockResolvedValue('{}');
 
-    // Create a new KnowledgeGraphManager instance
-    kg = new KnowledgeGraphManager(testFilePath);
+    // Create a new MockProjectManager instance
+    projectManager = new MockProjectManager();
+
+    // Create a new KnowledgeGraphManager instance with MockProjectManager
+    kg = new KnowledgeGraphManager(projectManager as unknown as ProjectManager);
   });
 
   afterEach(() => {

--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -95,6 +95,14 @@ export class KnowledgeGraphManager {
   }
 
   /**
+   * Get the name of the current active project
+   * @returns The current project name
+   */
+  getCurrentProject(): string {
+    return this.projectManager.getCurrentProject();
+  }
+
+  /**
    * Switch to a different project and load its data
    * @param projectName Name of the project to switch to
    * @returns Object with success status and message
@@ -104,7 +112,7 @@ export class KnowledgeGraphManager {
       // First, flush any pending changes to the current project
       await this.flush();
       console.log(
-        `[KnowledgeGraphManager] Flushed changes to current project: ${this.projectManager.getCurrentProject()}`,
+        `[KnowledgeGraphManager] Flushed changes to current project: ${this.getCurrentProject()}`,
       );
 
       // Use the project manager to switch projects

--- a/src/engine/ProjectManager.test.ts
+++ b/src/engine/ProjectManager.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ProjectManager } from './ProjectManager';
+import { CFG, FileOps } from '../config';
+
+// Mock config module
+vi.mock('../config.ts', () => {
+  return {
+    CFG: {
+      CURRENT_PROJECT: 'default',
+      getProjectMemoryFilePath: vi.fn((projectName) => `/test/path/kg.${projectName}.json`),
+      listProjects: vi.fn(() => ['default', 'project1', 'project2']),
+      createProject: vi.fn(() => true),
+      switchProject: vi.fn(() => true),
+    },
+    FileOps: {
+      getProjectFilePath: vi.fn((projectName) => `/test/path/kg.${projectName}.json`),
+      listProjectFiles: vi.fn(() => ['default', 'project1', 'project2']),
+      createProjectFile: vi.fn(() => true),
+      setCurrentProjectFile: vi.fn(() => true),
+    },
+  };
+});
+
+describe('ProjectManager', () => {
+  let projectManager: ProjectManager;
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Create ProjectManager instance
+    projectManager = new ProjectManager();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Project Management', () => {
+    it('should get the current project name', () => {
+      expect(projectManager.getCurrentProject()).toBe('default');
+    });
+
+    it('should get the current project path', () => {
+      expect(projectManager.getCurrentProjectPath()).toBe('/test/path/kg.default.json');
+      expect(FileOps.getProjectFilePath).toHaveBeenCalledWith('default');
+    });
+
+    it('should get a specific project path', () => {
+      expect(projectManager.getProjectPath('project1')).toBe('/test/path/kg.project1.json');
+      expect(FileOps.getProjectFilePath).toHaveBeenCalledWith('project1');
+    });
+
+    it('should list available projects', () => {
+      const projects = projectManager.listProjects();
+      expect(projects).toEqual(['default', 'project1', 'project2']);
+      expect(FileOps.listProjectFiles).toHaveBeenCalled();
+    });
+
+    it('should validate project names correctly', () => {
+      // Valid project names
+      expect(projectManager.validateProjectName('valid-project')).toEqual({ valid: true });
+      expect(projectManager.validateProjectName('valid_project')).toEqual({ valid: true });
+      expect(projectManager.validateProjectName('validProject123')).toEqual({ valid: true });
+
+      // Invalid project names
+      expect(projectManager.validateProjectName('')).toEqual({
+        valid: false,
+        error: 'Project name cannot be empty',
+      });
+      expect(projectManager.validateProjectName('invalid/project')).toEqual({
+        valid: false,
+        error: 'Project name can only contain letters, numbers, dashes, and underscores',
+      });
+      expect(projectManager.validateProjectName('invalid project')).toEqual({
+        valid: false,
+        error: 'Project name can only contain letters, numbers, dashes, and underscores',
+      });
+      expect(projectManager.validateProjectName('a'.repeat(51))).toEqual({
+        valid: false,
+        error: 'Project name is too long (max 50 characters)',
+      });
+    });
+
+    it('should create a new project', async () => {
+      const result = await projectManager.createProject('newproject');
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Successfully created project: newproject');
+      expect(FileOps.createProjectFile).toHaveBeenCalledWith('newproject');
+    });
+
+    it('should handle errors when creating a project', async () => {
+      // Mock createProjectFile to return false (project already exists)
+      vi.spyOn(FileOps, 'createProjectFile').mockReturnValue(false);
+
+      const result = await projectManager.createProject('project1');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Project 'project1' already exists");
+    });
+
+    it('should reject invalid project names when creating', async () => {
+      const result = await projectManager.createProject('invalid/project');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe(
+        'Project name can only contain letters, numbers, dashes, and underscores',
+      );
+      expect(FileOps.createProjectFile).not.toHaveBeenCalled();
+    });
+
+    it('should switch to an existing project', async () => {
+      const result = await projectManager.switchProject('project1');
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Successfully switched to project: project1');
+      expect(FileOps.setCurrentProjectFile).toHaveBeenCalledWith('project1');
+    });
+
+    it('should handle errors when switching projects', async () => {
+      // Mock setCurrentProjectFile to return false (switch failed)
+      vi.spyOn(FileOps, 'setCurrentProjectFile').mockReturnValue(false);
+
+      const result = await projectManager.switchProject('nonexistent');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Project 'nonexistent' does not exist");
+    });
+
+    it('should reject invalid project names when switching', async () => {
+      const result = await projectManager.switchProject('invalid/project');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe(
+        'Project name can only contain letters, numbers, dashes, and underscores',
+      );
+      expect(FileOps.setCurrentProjectFile).not.toHaveBeenCalled();
+    });
+
+    it('should handle non-existent projects when switching', async () => {
+      // Mock listProjectFiles to return only default project
+      vi.spyOn(FileOps, 'listProjectFiles').mockReturnValue(['default']);
+
+      const result = await projectManager.switchProject('nonexistent');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Project 'nonexistent' does not exist");
+      expect(FileOps.setCurrentProjectFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/engine/ProjectManager.ts
+++ b/src/engine/ProjectManager.ts
@@ -1,0 +1,143 @@
+import { CFG, FileOps } from '../config.ts';
+
+/**
+ * ProjectManager handles project-related operations for the knowledge graph system.
+ * It manages project creation, switching, and validation.
+ */
+export class ProjectManager {
+  /**
+   * Creates a new ProjectManager instance.
+   */
+  constructor() {
+    console.log(`[ProjectManager] Initialized with current project: ${this.getCurrentProject()}`);
+  }
+
+  /**
+   * Get the name of the current active project
+   * @returns The current project name
+   */
+  getCurrentProject(): string {
+    return CFG.CURRENT_PROJECT;
+  }
+
+  /**
+   * Get the file path for the current project
+   * @returns The file path for the current project
+   */
+  getCurrentProjectPath(): string {
+    return FileOps.getProjectFilePath(this.getCurrentProject());
+  }
+
+  /**
+   * Get the file path for a specific project
+   * @param projectName The name of the project
+   * @returns The file path for the specified project
+   */
+  getProjectPath(projectName: string): string {
+    return FileOps.getProjectFilePath(projectName);
+  }
+
+  /**
+   * List all available knowledge graph projects
+   * @returns Array of project names
+   */
+  listProjects(): string[] {
+    return FileOps.listProjectFiles();
+  }
+
+  /**
+   * Validate a project name for format and security constraints
+   * @param projectName The project name to validate
+   * @returns Object with validation result and optional error message
+   */
+  validateProjectName(projectName: string): { valid: boolean; error?: string } {
+    // Check for empty string
+    if (!projectName || projectName.trim() === '') {
+      return { valid: false, error: 'Project name cannot be empty' };
+    }
+
+    // Check for valid characters (alphanumeric, dash, underscore)
+    const validNameRegex = /^[a-zA-Z0-9_-]+$/;
+    if (!validNameRegex.test(projectName)) {
+      return {
+        valid: false,
+        error: 'Project name can only contain letters, numbers, dashes, and underscores',
+      };
+    }
+
+    // Check for reasonable length
+    if (projectName.length > 50) {
+      return { valid: false, error: 'Project name is too long (max 50 characters)' };
+    }
+
+    return { valid: true };
+  }
+
+  /**
+   * Switch to a different knowledge graph project
+   * @param projectName Name of the project to switch to
+   * @returns Object with success status and message
+   */
+  async switchProject(projectName: string): Promise<{ success: boolean; message: string }> {
+    try {
+      // Validate project name
+      const validation = this.validateProjectName(projectName);
+      if (!validation.valid) {
+        return { success: false, message: validation.error || 'Invalid project name' };
+      }
+
+      // Check if project exists
+      const projects = this.listProjects();
+      if (!projects.includes(projectName) && projectName !== 'default') {
+        return { success: false, message: `Project '${projectName}' does not exist` };
+      }
+
+      // Switch to the new project in the configuration
+      const success = FileOps.setCurrentProjectFile(projectName);
+      if (!success) {
+        return { success: false, message: `Failed to switch to project: ${projectName}` };
+      }
+
+      console.log(`[ProjectManager] Successfully switched to project: ${projectName}`);
+      return { success: true, message: `Successfully switched to project: ${projectName}` };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`[ProjectManager] Error switching to project ${projectName}:`, errorMessage);
+      return { success: false, message: `Error switching to project: ${errorMessage}` };
+    }
+  }
+
+  /**
+   * Create a new knowledge graph project
+   * @param projectName Name of the new project to create
+   * @returns Object with success status and message
+   */
+  async createProject(projectName: string): Promise<{ success: boolean; message: string }> {
+    try {
+      // Validate project name
+      const validation = this.validateProjectName(projectName);
+      if (!validation.valid) {
+        return { success: false, message: validation.error || 'Invalid project name' };
+      }
+
+      // Check if project already exists
+      const projects = this.listProjects();
+      if (projects.includes(projectName)) {
+        return { success: false, message: `Project '${projectName}' already exists` };
+      }
+
+      // Create the new project
+      const success = FileOps.createProjectFile(projectName);
+      if (!success) {
+        return { success: false, message: `Failed to create project: ${projectName}` };
+      }
+
+      console.log(`[ProjectManager] Successfully created project: ${projectName}`);
+      return { success: true, message: `Successfully created project: ${projectName}` };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`[ProjectManager] Error creating project ${projectName}:`, errorMessage);
+      return { success: false, message: `Error creating project: ${errorMessage}` };
+    }
+  }
+}


### PR DESCRIPTION
refactor(config): improve file operations API and maintain backward compatibility (not that anyone is using this atm..)

- Create dedicated FileOps namespace with intuitive method names:
  - getProjectMemoryFilePath → getProjectFilePath
  - listProjects → listProjectFiles
  - createProject → createProjectFile
  - switchProject → setCurrentProjectFile

- Reorganize config.ts into logical sections:
  - Path Configuration
  - Project Configuration
  - File Operations
  - Configuration Constants

- Update ProjectManager to use the new FileOps API
- Add comprehensive documentation for all functions
- Maintain backward compatibility via legacy method aliases
- Update tests to use the new API

This refactoring improves code organization and readability while providing a clearer separation between configuration constants and file operations.