### PR TITLE
chore: remove summarize init

### DIFF
--- a/src/agents/Summarize.ts
+++ b/src/agents/Summarize.ts
@@ -50,16 +50,6 @@ export class SummarizationAgent {
   }
 
   /**
-   * Initializes or reinitializes the agent.
-   * This can be called when switching projects to reset internal state.
-   */
-  init(): void {
-    console.log(
-      `[SummarizationAgent] Initialized for project: ${this.knowledgeGraph.getCurrentProject()}`,
-    );
-  }
-
-  /**
    * Summarizes a segment of nodes from the knowledge graph.
    * @param nodes Array of DagNode objects to summarize
    * @returns A promise that resolves to a SummarizationResult with just the summary text

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,12 +196,6 @@ async function main() {
 
       const result = await kg.switchProject(a.projectName);
 
-      // Reload dependencies if project switch was successful
-      if (result.success) {
-        // Reinitialize the summarization agent with the updated knowledge graph
-        summarizationAgent.init();
-      }
-
       return {
         content: [
           {


### PR DESCRIPTION
refactor(summarization): remove unnecessary init method from SummarizationAgent

- Remove init method that only logged a message but didn't reset any state
- Remove call to init method in switch_project tool handler